### PR TITLE
Patch for infinite money through building removal

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/ui/BuildingMenu.java
+++ b/UniSim/core/src/main/java/io/github/unisim/ui/BuildingMenu.java
@@ -105,6 +105,9 @@ public class BuildingMenu {
           if (world.selectedBuilding == buildings.get(buildingIndex)) {
             world.selectedBuilding = null;
           } else {
+            if (world.isRemovalMode) {
+                return;
+            }
             world.selectedBuilding = buildings.get(buildingIndex);
             buildingInfoLabel.setText(world.selectedBuilding.name + " - Press 'R' to rotate");
             if (world.selectedBuilding.flipped) {


### PR DESCRIPTION
Bug fixed.

The bug occurred as the selected building in the placed buildings list and would always overlap with the mouse, which used that list when removing the building and applying the refund. This allowed the building to always be refunded even when it was never placed.

This was prevented by not allowing any buildings to be selected while in building removal mode. This should prevent further occurrences of this bug.