### PR TITLE
MoneyTracker Bug Fixes

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/finance/MoneyTracker.java
+++ b/UniSim/core/src/main/java/io/github/unisim/finance/MoneyTracker.java
@@ -29,6 +29,9 @@ public class MoneyTracker {
     }
 
     public void updateMoney() {
+        if (GameState.gameOver) {
+            return;
+        }
         if (GameState.paused) {
             return;
         }

--- a/UniSim/core/src/main/java/io/github/unisim/world/World.java
+++ b/UniSim/core/src/main/java/io/github/unisim/world/World.java
@@ -439,6 +439,7 @@ public class World {
     initIsometricTransform();
     buildingManager = new BuildingManager(isoTransform);
     selectedBuilding = null;
+    moneyTracker = new MoneyTracker(500);
   }
 
   /**


### PR DESCRIPTION
- Money no longer keeps accumulating when the game is over
- MoneyTracker resets when game ends so that when a new game is started the player will start with the right initial amount of money