### PR TITLE
Updated build scripts

### DIFF
--- a/UniSim/build.gradle
+++ b/UniSim/build.gradle
@@ -10,7 +10,6 @@ buildscript {
   }
   dependencies {
 
-
   }
 }
 
@@ -29,7 +28,10 @@ allprojects {
 
 configure(subprojects) {
   apply plugin: 'java-library'
-  sourceCompatibility = 17
+
+  java {
+    sourceCompatibility = JavaVersion.VERSION_17
+  }
 
   // From https://lyze.dev/2021/04/29/libGDX-Internal-Assets-List/
   // The article can be helpful when using assets.txt in your project.

--- a/UniSim/lwjgl3/build.gradle
+++ b/UniSim/lwjgl3/build.gradle
@@ -1,7 +1,12 @@
-
 buildscript {
   repositories {
+    mavenCentral()
+    maven { url 'https://s01.oss.sonatype.org' }
     gradlePluginPortal()
+    mavenLocal()
+    google()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
   }
   dependencies {
     if(enableGraalNative == 'true') {
@@ -14,17 +19,23 @@ plugins {
   id "application"
 }
 
-
 import io.github.fourlastor.construo.Target
 
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
-mainClassName = 'io.github.unisim.lwjgl3.Lwjgl3Launcher'
-application.setMainClass(mainClassName)
+
+application {
+  mainClass.set('io.github.unisim.lwjgl3.Lwjgl3Launcher')
+}
+
 eclipse.project.name = appName + '-lwjgl3'
-java.sourceCompatibility = 17
-java.targetCompatibility = 17
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
 if (JavaVersion.current().isJava9Compatible()) {
-        compileJava.options.release.set(17)
+  compileJava.options.release.set(17)
 }
 
 dependencies {
@@ -34,8 +45,7 @@ dependencies {
 
   if(enableGraalNative == 'true') {
     implementation "io.github.berstanio:gdx-svmhelper-backend-lwjgl3:$graalHelperVersion"
-    }
-
+  }
 }
 
 def os = System.properties['os.name'].toLowerCase()
@@ -48,22 +58,22 @@ run {
 }
 
 jar {
-// sets the name of the .jar file this produces to the name of the game or app, with the version after.
+  // sets the name of the .jar file this produces to the name of the game or app, with the version after.
   archiveFileName.set("${appName}-${projectVersion}.jar")
-// the duplicatesStrategy matters starting in Gradle 7.0; this setting works.
+  // the duplicatesStrategy matters starting in Gradle 7.0; this setting works.
   duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
   dependsOn configurations.runtimeClasspath
   from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-// these "exclude" lines remove some unnecessary duplicate files in the output JAR.
+  // these "exclude" lines remove some unnecessary duplicate files in the output JAR.
   exclude('META-INF/INDEX.LIST', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA')
   dependencies {
     exclude('META-INF/INDEX.LIST', 'META-INF/maven/**')
   }
-// setting the manifest makes the JAR runnable.
+  // setting the manifest makes the JAR runnable.
   manifest {
-    attributes 'Main-Class': project.mainClassName
+    attributes 'Main-Class': 'io.github.unisim.lwjgl3.Lwjgl3Launcher'
   }
-// this last step may help on some OSes that need extra instruction to make runnable JARs.
+  // this last step may help on some OSes that need extra instruction to make runnable JARs.
   doLast {
     file(archiveFile).setExecutable(true, false)
   }


### PR DESCRIPTION
This pull aims to remove the features deprecated by Gradle that prevent progression to Gradle v9.0. This change should allow for an easier migration to that version when it is released.