### PR TITLE
43-timer-bugfix

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/Timer.java
+++ b/UniSim/core/src/main/java/io/github/unisim/Timer.java
@@ -28,7 +28,9 @@ public class Timer {
    * @return - true if the timer is running and the time has been decremented, false otherwise.
    */
   public boolean tick(float deltaTime) {
-    remainingTime -= deltaTime;
+    if (deltaTime > 0) {
+        remainingTime -= deltaTime;
+    }
     if (remainingTime > 0) {
       return true;
     } else {


### PR DESCRIPTION
Fixed failing tests for the Timer class based on the tests written.

Changes assume that the tick function should not increase the amount of time remaining during the function. The way this is now handled was to just clamp the value to have to be greater than 0 to be removed from the remainingTime on the Timer.

A similar method is used to clamp the number of remaining seconds and remaining minutes on the Timer by clamping negative values to be zero.

The constructor also correctly sets the hasFinished variable when the Timer is constructed.