### PR TITLE
Remove unused dependency

### DIFF
--- a/UniSim/core/build.gradle
+++ b/UniSim/core/build.gradle
@@ -2,7 +2,6 @@
 eclipse.project.name = appName + '-core'
 
 dependencies {
-  api "com.badlogicgames.ashley:ashley:$ashleyVersion"
   api "com.badlogicgames.gdx:gdx:$gdxVersion"
   testImplementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
   testImplementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"

--- a/UniSim/gradle.properties
+++ b/UniSim/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xms512M -Xmx1G -Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-8
 org.gradle.configureondemand=false
-ashleyVersion=1.7.4
 graalHelperVersion=2.0.1
 enableGraalNative=false
 gdxVersion=1.12.1


### PR DESCRIPTION
Removes the unused 'ashley' dependency from the build scripts. This was included as part of a template and is not planned for usage. This should bring down the runtime of the CI pipeline as this dependency was still compiled.