### PR TITLE
Add debugging gradle test in VS code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Gradle Test",
+            "type": "java",
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 5005
+        }
+    ]
+}

--- a/UniSim/core/build.gradle
+++ b/UniSim/core/build.gradle
@@ -11,6 +11,13 @@ dependencies {
   }
 }
 
+test {
+    // Enable debugging for tests
+    if (project.hasProperty('debug') && project.debug == 'true') {
+        jvmArgs += ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"]
+    }
+}
+
 testing {
   suites {
     test {
@@ -26,6 +33,10 @@ testing {
         all {
           testTask.configure {
             shouldRunAfter(test)
+            useJUnitJupiter()
+            if (project.hasProperty('debug') && project.debug == 'true') {
+              jvmArgs += ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005"]
+            }
           }
         }
       }


### PR DESCRIPTION
Currently, the tests on vs code are run in a separate container for debugging. This can result in different behaviour compared to running the tests in the gradle environment. This allows for the tests to be compiled to listen for a debugger on port 5005. This is defined in the `Attach to Gradle Test` launch script.

To enter debug mode for tests in VS code run these commands
```
./gradlew test --rerun-tasks -Pdebug=true
```
Then the attach script has to be run using the debug menu.