### PR TITLE
Updated workflows to upload test reports

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,3 +25,11 @@ jobs:
 
       - name: Test with Gradle Wrapper
         run: cd UniSim && ./gradlew test
+
+      - name: Archive Test Report
+        if: always()
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: test-reports
+          path: UniSim/core/build/reports/tests/test
+          retention-days: 14

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,13 @@ jobs:
       - name: Upload JAR
         uses: actions/upload-artifact@v4.4.3
         with:
-          # Artifact name
           name: unisim.jar
-          # A file, directory or wildcard pattern that describes what to upload
           path: UniSim/lwjgl3/build/libs/UniSim-1.0.0.jar
+
+      - name: Archive Test Report
+        if: always()
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: test-reports
+          path: UniSim/core/build/reports/tests/test
+          retention-days: 14


### PR DESCRIPTION
Closes #84.

Should attach the test reports from the CI as an artifact.