### PR TITLE
Fix #76

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/ui/PauseScreen.java
+++ b/UniSim/core/src/main/java/io/github/unisim/ui/PauseScreen.java
@@ -56,6 +56,7 @@ public class PauseScreen implements Screen {
                     @Override
                     protected void result(Object object) {
                         if ((Boolean) object) {
+                            GameState.gameOver = true;
                             GameState.currentScreen = GameState.startScreen;
                         }
                     }


### PR DESCRIPTION
Closes #76.

Fixes a bug where exiting the game through the pause menu would not correctly reset the world upon playing a new game.

This was fixed by setting the game to be over when exited through the pause menu.