### PR TITLE
Add parallel build to the CI project properties

### DIFF
--- a/UniSim/gradle.properties
+++ b/UniSim/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xms512M -Xmx1G -Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-8
 org.gradle.configureondemand=false
+org.gradle.parallel=true
 graalHelperVersion=2.0.1
 enableGraalNative=false
 gdxVersion=1.12.1


### PR DESCRIPTION
Added parallel as a build argument in the properties file. This should decrease build times in the CI pipeline as the all runners provided have at least two cores.