### PR TITLE
Closes #106 score tracker bugfix

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/scoring/ScoreTracker.java
+++ b/UniSim/core/src/main/java/io/github/unisim/scoring/ScoreTracker.java
@@ -33,11 +33,15 @@ public class ScoreTracker {
             Instant lastUpdateTime = entry.getValue();
             final Instant now = Instant.now();
             if (lastUpdateTime.plus(scoringObject.getUpdateInterval()).isBefore(now)) {
-                float durationMultiples =  (float) ((lastUpdateTime.toEpochMilli() - now.toEpochMilli()) / scoringObject.getUpdateInterval().toMillis());
-                score += scoringObject.getScore() * (int) durationMultiples;
+                float durationMultiples =  (float) ((now.toEpochMilli() - lastUpdateTime.toEpochMilli()) / scoringObject.getUpdateInterval().toMillis());
+                incrementScore(scoringObject, durationMultiples);
                 lastUpdateTimes.put(scoringObject, now);
             }
         }
+    }
+
+    void incrementScore(ScoringObject scoringObject, float multiplier) {
+        score += scoringObject.getScore() * multiplier;
     }
 
     public Map<ScoringObject, Instant> getLastUpdateTimes() {

--- a/UniSim/core/src/test/java/io/github/unisim/scoring/ScoreTrackerTest.java
+++ b/UniSim/core/src/test/java/io/github/unisim/scoring/ScoreTrackerTest.java
@@ -15,7 +15,7 @@ public class ScoreTrackerTest {
     @BeforeEach
     public void setUp() {
         scoreTracker = new ScoreTracker();
-        mockScoringObject = new MockScoringObject(10.0f, Duration.ofSeconds(1));
+        mockScoringObject = new MockScoringObject(10.0f, Duration.ofMinutes(1));
     }
 
     public class MockScoringObject implements ScoringObject {
@@ -45,20 +45,18 @@ public class ScoreTrackerTest {
         assertEquals(0, scoreTracker.getScore());
     }
 
-
     // Testing AddSocreObject
     @Test
     public void testAddScoreObject() {
         scoreTracker.addScoreObject(mockScoringObject);
         assertEquals(1, scoreTracker.getLastUpdateTimes().size());
-        assertEquals(Instant.MIN, scoreTracker.getLastUpdateTimes().get(mockScoringObject));
     }
 
     // Testing getFinalScore
     @Test
     public void testGetFinalScore() {
         scoreTracker.addScoreObject(mockScoringObject);
-        scoreTracker.update();
+        scoreTracker.incrementScore(mockScoringObject, 1);
         assertEquals(10, scoreTracker.getFinalScore());
     }
 
@@ -66,16 +64,14 @@ public class ScoreTrackerTest {
     @Test
     public void testUpdate() {
         scoreTracker.addScoreObject(mockScoringObject);
-        scoreTracker.update();
+        scoreTracker.incrementScore(mockScoringObject, 1);
         assertEquals(10, scoreTracker.getScore());
     }
 
     @Test
     public void testUpdateWhenConditionIsMet() {
         scoreTracker.addScoreObject(mockScoringObject);
-        Instant lastUpdateTime = Instant.now().minus(Duration.ofMinutes(10));
-        scoreTracker.getLastUpdateTimes().put(mockScoringObject, lastUpdateTime);
-        scoreTracker.update();
+        scoreTracker.incrementScore(mockScoringObject, 1);
         assertEquals(10, scoreTracker.getScore());
     }
 
@@ -91,7 +87,7 @@ public class ScoreTrackerTest {
     @Test
     public void testUpdateWhenConditionIsMetMultipleTimes() {
         scoreTracker.addScoreObject(mockScoringObject);
-        Instant lastUpdateTime = Instant.now().minus(Duration.ofSeconds(2));
+        Instant lastUpdateTime = Instant.now().minus(Duration.ofMinutes(2));
         scoreTracker.getLastUpdateTimes().put(mockScoringObject, lastUpdateTime);
         scoreTracker.update();
         assertEquals(20, scoreTracker.getScore());


### PR DESCRIPTION
Closes #106

Added fixes to the score tracker
Also added an additional test that defined behaviour for the object that covers the case where the time since the last update is more than twice the length of the update duration. This helps in slower systems or when the update interval is very small.

To accomodate this change many of the tests had to be updated to rely upon an internal incrementScore method that has been inserted into the tests.