### PR TITLE
Reduced visibility of the lastUpdateTimes map

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/scoring/ScoreTracker.java
+++ b/UniSim/core/src/main/java/io/github/unisim/scoring/ScoreTracker.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public class ScoreTracker {
 
     private float score;
-    private Map<ScoringObject, Instant> lastUpdateTimes;
+    Map<ScoringObject, Instant> lastUpdateTimes;
 
     public ScoreTracker() {
         score = 0;
@@ -42,10 +42,6 @@ public class ScoreTracker {
 
     void incrementScore(ScoringObject scoringObject, float multiplier) {
         score += scoringObject.getScore() * multiplier;
-    }
-
-    public Map<ScoringObject, Instant> getLastUpdateTimes() {
-        return lastUpdateTimes;
     }
 
 }

--- a/UniSim/core/src/test/java/io/github/unisim/scoring/ScoreTrackerTest.java
+++ b/UniSim/core/src/test/java/io/github/unisim/scoring/ScoreTrackerTest.java
@@ -49,7 +49,7 @@ public class ScoreTrackerTest {
     @Test
     public void testAddScoreObject() {
         scoreTracker.addScoreObject(mockScoringObject);
-        assertEquals(1, scoreTracker.getLastUpdateTimes().size());
+        assertEquals(1, scoreTracker.lastUpdateTimes.size());
     }
 
     // Testing getFinalScore
@@ -79,7 +79,7 @@ public class ScoreTrackerTest {
     public void testUpdateWhenConditionIsNotMet() {
         scoreTracker.addScoreObject(mockScoringObject);
         Instant lastUpdateTime = Instant.now().plus(Duration.ofMinutes(1));
-        scoreTracker.getLastUpdateTimes().put(mockScoringObject, lastUpdateTime);
+        scoreTracker.lastUpdateTimes.put(mockScoringObject, lastUpdateTime);
         scoreTracker.update();
         assertEquals(0, scoreTracker.getScore());
     }
@@ -88,7 +88,7 @@ public class ScoreTrackerTest {
     public void testUpdateWhenConditionIsMetMultipleTimes() {
         scoreTracker.addScoreObject(mockScoringObject);
         Instant lastUpdateTime = Instant.now().minus(Duration.ofMinutes(2));
-        scoreTracker.getLastUpdateTimes().put(mockScoringObject, lastUpdateTime);
+        scoreTracker.lastUpdateTimes.put(mockScoringObject, lastUpdateTime);
         scoreTracker.update();
         assertEquals(20, scoreTracker.getScore());
     }


### PR DESCRIPTION
This reduces the visibility of the internal Map storing the lastUpdateTimes in the ScoreTracker object. There was a public method that returned the Map, which allowed for these times to be mutated externally. However, this behaviour is needed in testing so the Map has been made available at the package level allowing for lower level access to this object for testing purposes.