### PR TITLE
Closes #111 MoneyTracker bugfix

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/finance/MoneyTracker.java
+++ b/UniSim/core/src/main/java/io/github/unisim/finance/MoneyTracker.java
@@ -3,8 +3,6 @@ package io.github.unisim.finance;
 import java.time.Duration;
 import java.time.Instant;
 
-import io.github.unisim.GameState;
-
 public class MoneyTracker {
     private static final Duration MONEY_UPDATE_INTERVAL = Duration.ofSeconds(1);
     private static final int MONEY_UPDATE_AMOUNT = 100;
@@ -33,12 +31,6 @@ public class MoneyTracker {
     }
 
     public void updateMoney() {
-        if (GameState.gameOver) {
-            return;
-        }
-        if (GameState.paused) {
-            return;
-        }
         Instant currentTime = Instant.now();
         Duration timeSinceLastUpdate = Duration.between(lastUpdateTime, currentTime);
         if (timeSinceLastUpdate.compareTo(MONEY_UPDATE_INTERVAL) >= 0) {

--- a/UniSim/core/src/main/java/io/github/unisim/world/World.java
+++ b/UniSim/core/src/main/java/io/github/unisim/world/World.java
@@ -91,7 +91,9 @@ public class World {
   }
 
   public void update() {
-    moneyTracker.updateMoney();
+    if (!GameState.gameOver && !GameState.paused) {
+      moneyTracker.updateMoney();
+    }
     satisfactionTracker.updateSatisfaction(buildingManager.getBuildings(), buildingManager.getPreviewBuilding(), numberOfStudents);
     scoreTracker.update();
 

--- a/UniSim/core/src/test/java/io/github/unisim/finance/MoneyTrackerTest.java
+++ b/UniSim/core/src/test/java/io/github/unisim/finance/MoneyTrackerTest.java
@@ -6,9 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
-import io.github.unisim.GameState;
-
-
 
 public class MoneyTrackerTest {
 
@@ -114,25 +111,8 @@ public class MoneyTrackerTest {
         assertEquals(100,tracker.getMoney());
     }
 
-    // Testing updateMoney method
     @Test
-    public void testUpdateMoneyWhenPaused() {
-        tracker = new MoneyTracker(100);
-        GameState.paused = true;
-        tracker.updateMoney();
-        assertEquals(100, tracker.getMoney());
-    }
-
-    @Test
-    public void testUpdateMoneyWhenGameOver() {
-        tracker = new MoneyTracker(100);
-        GameState.gameOver = true;
-        tracker.updateMoney();
-        assertEquals(100, tracker.getMoney());
-    }
-
-    @Test
-    public void testUpdateMoneyTimeSinceLastUpateIsLessThanInterval() {
+    public void testUpdateMoneyTimeSinceLastUpdateIsLessThanInterval() {
         tracker = new MoneyTracker(0);
         tracker.lastUpdateTime = Instant.now();
         int money = tracker.getMoney();


### PR DESCRIPTION
Closes #111.

This refactors all of the static references to GameState out of the MoneyTacker object. This makes it very hard to test so the function to update the money now requires manual checking that the game is not paused or over. This check has been moved to the World update function.