### PR TITLE
Improved achievements loading

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/achievements/AchievementManager.java
+++ b/UniSim/core/src/main/java/io/github/unisim/achievements/AchievementManager.java
@@ -176,12 +176,71 @@ public class AchievementManager {
                     functionTemplate, scoreModifierValue, progress, unlocked, hidden);
             achievements.add(achievement);
         }
+        if (updateAchievementsToDefinitions(achievements)) {
+            // Save the updated achievements since there was a change
+            save();
+        }
         Optional<List<DefinedAchievements>> undefinedAchievements =
                 DefinedAchievements.getMissingAchievements(achievements);
         if (undefinedAchievements.isPresent()) {
             undefinedAchievements.get().forEach(a -> achievements.add(new Achievement(a)));
             save();
         }
+    }
+
+    /**
+     * Updates the fixed fields of the achievements to match the definitions.
+     *
+     * <p>
+     * This function works in place and modifies the list of achievements internally. This creates a
+     * new instance of the achievement if any of the fixed fields do not match the definitions that
+     * replace the old achievement.
+     * </p>
+     * <p>
+     * This method will update the achievements to match the definitions. This uses the names of
+     * the achievements to match them to the definitions, so the names must be unique and not change.
+     * </p>
+     * <p>
+     * This method will update the fixed fields defined in the {@link DefinedAchievements} enum. This
+     * function will not modify the changing fields of the achievements, such as the progress or
+     * unlock fields.
+     * </p>
+     *
+     * @param achievements the list of achievements to update
+     * @return if any achievements were updated
+     */
+    private static final boolean updateAchievementsToDefinitions(List<Achievement> achievements) {
+        boolean hadUpdate = false;
+        int index = 0;
+        for (Achievement a : achievements) {
+            Optional<DefinedAchievements> definitionOptional = DefinedAchievements.getByName(a.name);
+            if (definitionOptional.isEmpty()) {
+                continue;
+            }
+            DefinedAchievements definition = definitionOptional.get();
+            boolean shouldUpdate = !(a.description.equals(definition.description)
+                    && a.functionTemplate.equals(definition.functionTemplate)
+                    && a.scoreModifierValue == definition.scoreModifierValue
+                    && a.hidden == definition.hidden);
+            if (shouldUpdate) {
+                hadUpdate = true;
+                Achievement newAchievement = new Achievement(definition);
+                // Maintain the tracked fields states
+                newAchievement.progress = a.progress;
+                newAchievement.unlocked = a.unlocked;
+                newAchievement.unlockTime = a.unlockTime;
+                achievements.set(index, newAchievement);
+                Gdx.app.log("AchievementManager update",
+                        "Updated achievement " + a.name + " to match definition");
+            }
+            index += 1;
+        }
+        // Log if there was an update
+        if (hadUpdate) {
+            Gdx.app.log("AchievementManager update", "Updated achievements to match definitions");
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/UniSim/core/src/main/java/io/github/unisim/achievements/DefinedAchievements.java
+++ b/UniSim/core/src/main/java/io/github/unisim/achievements/DefinedAchievements.java
@@ -73,7 +73,7 @@ public enum DefinedAchievements {
      * @param name the name of the achievement
      * @return the defined achievement if it exists, otherwise an empty optional
      */
-    private static Optional<DefinedAchievements> getByName(String name) {
+    static Optional<DefinedAchievements> getByName(String name) {
         for (DefinedAchievements a : values()) {
             if (a.name.equals(name)) {
                 return Optional.of(a);


### PR DESCRIPTION
Improved the loading of the achievements file so that the achievements update when loaded if the DefinedAchievements enum has had an update to it that causes a change in the final fields then the loaded achievement is updated to reflect this.

This change was made to make updating achievements between versions easier.

The fields in the Achievement class were left as final as this prevents these fields changing at runtime despite the need to create a new instance for the Achievement that replaces the old one.

In the future this could potentially be improved by causing the file to only store the mutable fields and use a new constructor using the DefinedAchievement and mutable fields to fill in the spaces. This would reduce the storage space needed for the file.