### PR TITLE
Bump libGDX dependency version to 0.13.0

### DIFF
--- a/UniSim/gradle.properties
+++ b/UniSim/gradle.properties
@@ -4,6 +4,6 @@ org.gradle.configureondemand=false
 org.gradle.parallel=true
 graalHelperVersion=2.0.1
 enableGraalNative=false
-gdxVersion=1.12.1
+gdxVersion=1.13.0
 mockitoVersion=5.14.2
 projectVersion=1.0.0


### PR DESCRIPTION
Bumps libGDX to the newest version. This brings a number of bug fixes and requires no current changes to the codebase.