### PR TITLE
Improved intuition for the building capacity bars in the management menu

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/ui/ManagementMenu.java
+++ b/UniSim/core/src/main/java/io/github/unisim/ui/ManagementMenu.java
@@ -175,7 +175,7 @@ public class ManagementMenu {
             Label label = buildingCapacityLabels.get(type);
             label.setText(capacities.get(type).toString());
             ProgressBar bar = buildingCapacityBars.get(type);
-            bar.setValue((float) (range - capacities.get(type)) / range);
+            bar.setValue((float) (capacities.get(type) - min) / range);
         }
         updateLabelPositions();
     }


### PR DESCRIPTION
Closes  #177.

Changed the formula for the bar fill in the ManagementMenu to make it so that the bar shows the relative difference between the building capacities rather than the need for more each of the building types. This is more intuitive than the previous implementation and should help users understand the menu better.
