### PR TITLE
Added basic preview info table to the BuildingMenu

### DIFF
--- a/UniSim/core/src/main/java/io/github/unisim/ui/BuildingMenu.java
+++ b/UniSim/core/src/main/java/io/github/unisim/ui/BuildingMenu.java
@@ -35,6 +35,7 @@ public class BuildingMenu {
       "", new Skin(Gdx.files.internal("ui/uiskin.json"))
   );
   private Table buildingInfoTable = new Table();
+  private BuildingPreviewMenu previewMenu;
 
   /**
    * Create a Building Menu and attach its actors and components to the provided stage.
@@ -190,6 +191,7 @@ public class BuildingMenu {
     currMenuEntry = navTableMap.get(BuildingType.RECREATION);
     currMenuEntry.addToStage(stage);
     stage.addActor(buildingInfoTable);
+    previewMenu = new BuildingPreviewMenu(stage);
   }
 
   /**
@@ -205,6 +207,7 @@ public class BuildingMenu {
       menuEntry.resize(width, height);
     }
     buildingInfoLabel.setFontScale(height * 0.0015f);
+    previewMenu.resize(width, height);
   }
 
   /**
@@ -215,10 +218,14 @@ public class BuildingMenu {
       buildingInfoLabel.setText("Game Over!");
     } else if (world.selectedBuilding == null) {
       buildingInfoLabel.setText("");
+      previewMenu.hideContent();
+    } else {
+        previewMenu.showContent(world.selectedBuilding);
     }
   }
 
   public void reset() {
     buildingInfoLabel.setText("");
+    previewMenu.hideContent();
   }
 }

--- a/UniSim/core/src/main/java/io/github/unisim/ui/BuildingPreviewMenu.java
+++ b/UniSim/core/src/main/java/io/github/unisim/ui/BuildingPreviewMenu.java
@@ -1,0 +1,131 @@
+package io.github.unisim.ui;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Cell;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import io.github.unisim.GameState;
+import io.github.unisim.building.Building;
+import io.github.unisim.utils.ResizableComponents;
+
+public class BuildingPreviewMenu {
+
+    private final Table previewTable;
+    private final Image background;
+
+    private final ResizableComponents resizableComponents;
+
+    private static final float normalisedWidth = 0.3f;
+    private static final float normalisedHeight = 0.25f;
+    private static final float normalisedLeftPadding = 0.01f;
+    private static final float normalisedTopPadding = 0.01f;
+
+    private final Table rightColumn;
+    private final Image previewImage;
+    private final Cell<Image> previewCell;
+    private final Label nameLabel;
+    private final Label sizeLabel;
+    private final Label capacityLabel;
+    private final Label costLabel;
+
+    private Building preview;
+
+    /**
+     * Creates a new BuildingPreviewMenu and attaches it's components to the provided stage
+     *
+     * @param stage The stage to attach the components to
+     */
+    public BuildingPreviewMenu(Stage stage) {
+        previewTable = new Table();
+
+        // Create solid white background
+        Pixmap pixmap = new Pixmap(100, 100, Pixmap.Format.RGB888);
+        pixmap.setColor(Color.WHITE);
+        pixmap.fill();
+        background = new Image(new Texture(pixmap));
+
+        final float boxSize = Math.min(stage.getWidth(), stage.getHeight());
+
+        nameLabel = new Label("", new Label.LabelStyle(GameState.iconTextFont, Color.BLACK));
+        previewTable.add(nameLabel).padLeft(2.5f).colspan(2).center().row();
+
+        previewImage = new Image();
+        previewCell = previewTable.add(previewImage).left().padLeft(2.5f).width(boxSize * normalisedWidth / 2.1f).height(boxSize * normalisedHeight / 1.5f);
+
+        rightColumn = new Table();
+        previewTable.add(rightColumn).expand().fill().row();
+
+        sizeLabel = new Label("", new Label.LabelStyle(GameState.iconTextFont, Color.BLACK));
+        capacityLabel = new Label("", new Label.LabelStyle(GameState.iconTextFont, Color.BLACK));
+        costLabel = new Label("", new Label.LabelStyle(GameState.iconTextFont, Color.BLACK));
+
+        rightColumn.add(sizeLabel).left().padLeft(2.5f).row();
+        rightColumn.add(capacityLabel).left().padLeft(2.5f).row();
+        rightColumn.add(costLabel).left().padLeft(2.5f).row();
+
+        resizableComponents = new ResizableComponents.Builder(boxSize, boxSize)
+                .addActor(previewTable)
+                .addActor(background)
+                .setNormalisedX(normalisedLeftPadding)
+                .setNormalisedY(normalisedTopPadding)
+                .setNormalisedWidth(normalisedWidth)
+                .setNormalisedHeight(normalisedHeight)
+                .build();
+
+        stage.addActor(background);
+        stage.addActor(previewTable);
+
+        preview = null;
+    }
+
+    /**
+     * Shows the information of the building in the preview menu
+     *
+     * <p>
+     * If the building is null, the content of the preview menu is hidden.
+     * </p>
+     *
+     * @param building The building to show the information of
+     */
+    public void showContent(Building building) {
+        if (building == null) {
+            hideContent();
+            return;
+        }
+        if (building == preview) {
+            return;
+        }
+        preview = building;
+        previewImage.setDrawable(new TextureRegionDrawable(building.texture));
+        nameLabel.setText(building.name);
+        sizeLabel.setText("Size: " + building.size.x + "x" + building.size.y);
+        capacityLabel.setText("Capacity: " + building.capacity);
+        costLabel.setText("Cost: $" + building.cost);
+    }
+
+    /**
+     * Hides the content of the preview menu
+     */
+    public void hideContent() {
+        if (preview == null) {
+            return;
+        }
+        preview = null;
+        previewImage.setDrawable(null);
+        nameLabel.setText("");
+        sizeLabel.setText("");
+        capacityLabel.setText("");
+        costLabel.setText("");
+    }
+
+    public void resize(int width, int height) {
+        int boxSize = Math.min(width, height);
+        resizableComponents.resize(boxSize, boxSize);
+        previewCell.width(boxSize * normalisedWidth / 2.1f).height(boxSize * normalisedHeight / 1.5f);
+    }
+}

--- a/UniSim/core/src/main/java/io/github/unisim/utils/ResizableComponents.java
+++ b/UniSim/core/src/main/java/io/github/unisim/utils/ResizableComponents.java
@@ -179,7 +179,11 @@ public class ResizableComponents {
         ResizableComponents internal;
 
         public Builder(Stage stage) {
-            internal = new ResizableComponents(stage.getWidth(), stage.getHeight());
+            this(stage.getWidth(), stage.getHeight());
+        }
+
+        public Builder(float width, float height) {
+            internal = new ResizableComponents(width, height);
         }
 
         public ResizableComponents build() {


### PR DESCRIPTION
Added a basic information table to allow the currently selected building to have some internal information shown to the player, guiding their actions.

This is a rough skeleton for how the menu should look but an issue will be opened to improve the UI of this table.

This merge is to allow for work to begin on #173, which requires this skeleton at a minimum for the developement to begin.
